### PR TITLE
Fix #13: Eliminate workflow warnings by updating github action to consume node 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,5 +20,5 @@ branding:
     icon: 'extension-icon.svg'
     color: 'blue'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'lib/main.js'


### PR DESCRIPTION
Relevant details: 
- #13 
- https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/