### PR TITLE
Allow customization of test run display name

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,11 @@ You can use the following parameters to configure the GitHub action.
 |`loadTestConfigFile`    | **Required** Path to the load test YAML configuration file. The path is fully qualified or relative to the default working directory.        |
 |`resourceGroup`     |  **Required** Name of the resource group that contains the Azure Load Testing resource.       |
 |`loadTestResource`     |   **Required** Name of an existing Azure Load Testing resource.      |
+|`loadTestRunName` |  **Optional** Name of the load test run. If not specified, the default value is the date and time. |
+|`loadTestRunDescription` | **Optional** Description of the load test run.  |
 |`secrets`   |   Array of JSON objects that consist of the **name** and **value** for each secret that is required by your Apache JMeter script. The name should match the secret name used in the Apache JMeter test script. |
 |`env`     |   Array of JSON objects that consist of the **name** and **value** for each environment variable that is required by your Apache JMeter script. The name should match the variable name used in the Apache JMeter test script. |
+|`
 
 The following YAML code snippet describes how to use the action in a GitHub Actions workflow.
 

--- a/action.yml
+++ b/action.yml
@@ -7,10 +7,10 @@ inputs:
   loadtestResource:
     description: 'Enter or Select the name of an existing Azure Load Testing resource'
     required: true
-  loadTestRunDisplayName:
+  loadtestRunName:
     description: 'Custom name for the load test run'
     required: false
-  loadTestRunDescription:
+  loadtestRunDescription:
     description: 'Custom description for the load test run'
     required: false
   resourceGroup:

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,9 @@ inputs:
   loadTestRunDisplayName:
     description: 'Custom name for the load test run'
     required: false
+  loadTestRunDescription:
+    description: 'Custom description for the load test run'
+    required: false
   resourceGroup:
     description: 'Enter or Select the Azure Resource Group that contains the Load test resource specified above'
     required: true

--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,9 @@ inputs:
   loadtestResource:
     description: 'Enter or Select the name of an existing Azure Load Testing resource'
     required: true
+  loadTestRunDisplayName:
+    description: 'Custom name for the load test run'
+    required: false
   resourceGroup:
     description: 'Enter or Select the Azure Resource Group that contains the Load test resource specified above'
     required: true

--- a/src/main.ts
+++ b/src/main.ts
@@ -181,7 +181,7 @@ async function createTestRun() {
     var urlSuffix = "test-runs/"+testRunId+"?tenantId="+tenantId+"&api-version=2022-11-01";
     urlSuffix = baseURL+urlSuffix;
     const ltres: string = core.getInput('loadTestResource');
-    const runDisplayName: string = core.getInput('loadTestRunDisplayName');
+    const runDisplayName: string = core.getInput('loadTestRunName');
     const runDescription: string = core.getInput('loadTestRunDescription');
     const subName = await map.getSubName();
     try {

--- a/src/main.ts
+++ b/src/main.ts
@@ -182,9 +182,10 @@ async function createTestRun() {
     urlSuffix = baseURL+urlSuffix;
     const ltres: string = core.getInput('loadTestResource');
     const runDisplayName: string = core.getInput('loadTestRunDisplayName');
+    const runDescription: string = core.getInput('loadTestRunDescription');
     const subName = await map.getSubName();
     try {
-        var startData = map.startTestData(testRunId, runDisplayName);
+        var startData = map.startTestData(testRunId, runDisplayName, runDescription);
         console.log("Creating and running a testRun for the test");
         let header = await map.createTestHeader();
         let startTestresult = await httpClient.patch(urlSuffix,JSON.stringify(startData),header);

--- a/src/main.ts
+++ b/src/main.ts
@@ -181,9 +181,10 @@ async function createTestRun() {
     var urlSuffix = "test-runs/"+testRunId+"?tenantId="+tenantId+"&api-version=2022-11-01";
     urlSuffix = baseURL+urlSuffix;
     const ltres: string = core.getInput('loadTestResource');
+    const runDisplayName: string = core.getInput('loadTestRunDisplayName');
     const subName = await map.getSubName();
     try {
-        var startData = map.startTestData(testRunId);
+        var startData = map.startTestData(testRunId, runDisplayName);
         console.log("Creating and running a testRun for the test");
         let header = await map.createTestHeader();
         let startTestresult = await httpClient.patch(urlSuffix,JSON.stringify(startData),header);

--- a/src/mappers.ts
+++ b/src/mappers.ts
@@ -132,10 +132,10 @@ export function dataPlaneHeader() {
     };
     return headers;
 }
-export function startTestData(testRunName:string) {
+export function startTestData(testRunName:string, runDisplayName: string) {
     var data = {
         testRunId: testRunName,
-        displayName: getDefaultTestRunName(),
+        displayName: runDisplayName ? runDisplayName : getDefaultTestRunName(),
         testId: testId,
         secrets: secretsRun,
         environmentVariables: envRun

--- a/src/mappers.ts
+++ b/src/mappers.ts
@@ -132,10 +132,11 @@ export function dataPlaneHeader() {
     };
     return headers;
 }
-export function startTestData(testRunName:string, runDisplayName: string) {
+export function startTestData(testRunName:string, runDisplayName: string, runDescription: string) {
     var data = {
         testRunId: testRunName,
         displayName: runDisplayName ? runDisplayName : getDefaultTestRunName(),
+        description: runDescription ? runDescription : 'Started using GitHub Actions',
         testId: testId,
         secrets: secretsRun,
         environmentVariables: envRun


### PR DESCRIPTION
The auto-generated display name for the test run makes it hard to work out (when there are a lot of runs) what each run was for.

```javascript
export function getDefaultTestRunName()
{
    const a = (new Date(Date.now())).toLocaleString()
    const b = a.split(", ")
    const c = a.split(" ")
    return "TestRun_"+b[0]+"_"+c[1]+c[2]
}
```

This PR adds an optional parameter to the action to set the test run display name and the description. 