### PR TITLE
Disabling PR Workflow for Forked PRs

### DIFF
--- a/.github/workflows/pr_check_load_test.yml
+++ b/.github/workflows/pr_check_load_test.yml
@@ -12,7 +12,6 @@ on:
 
 # NOTE: This workflow doesn't run on PRs against forks of this repositories
 # Since they won't have access to the repository secrets. Ref: https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
-# This will be fixed when testing is fixed for this GitHub Action.
 # CONFIGURATION
 # For help, go to https://github.com/Azure/Actions
 #

--- a/.github/workflows/pr_check_load_test.yml
+++ b/.github/workflows/pr_check_load_test.yml
@@ -6,10 +6,13 @@ on:
       - releases/*
     paths-ignore:
       - '**.md'
-  pull_request_target:
+  pull_request:
     branches:
       - 'releases/*'
 
+# NOTE: This workflow doesn't run on PRs against forks of this repositories
+# Since they won't have access to the repository secrets. Ref: https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+# This will be fixed when testing is fixed for this GitHub Action.
 # CONFIGURATION
 # For help, go to https://github.com/Azure/Actions
 #
@@ -32,13 +35,6 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
-    
-    - uses: actions/checkout@v2
-      name: Checkout from PR branch
-      with: 
-        repository: ${{ github.event.pull_request.head.repo.full_name }}
-        path: 'load-testing'
-        ref: ${{ github.event.pull_request.head.ref }}
 
     - name: Installing dependencies and building latest changes
       run: |

--- a/.github/workflows/pr_check_load_test.yml
+++ b/.github/workflows/pr_check_load_test.yml
@@ -10,7 +10,7 @@ on:
     branches:
       - 'releases/*'
 
-# NOTE: This workflow doesn't run on PRs against forks of this repositories
+# NOTE : This workflow doesn't run on PRs against forks of this repositories
 # Since they won't have access to the repository secrets. Ref: https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
 # CONFIGURATION
 # For help, go to https://github.com/Azure/Actions


### PR DESCRIPTION
Using trigger `pull_request_target` allows workflows from forked repos to get access to the secrets and GitHub tokens of this repository, [as specified here](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/).