### PR TITLE
Changes to support renaming of model and properties based on API review

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -95,7 +95,12 @@ function getTestAPI(validate) {
             if (testObj == null) {
                 throw new Error(util.ErrorCorrection(testResult));
             }
-            var inputScriptFileInfo = testObj.testType == mappers_1.TestType.URL ? testObj.inputArtifacts.urlTestsConfigFileInfo : testObj.inputArtifacts.testScriptFileInfo;
+            if (testObj.kind == null) {
+                testObj.kind = testObj.testType;
+            }
+            if (testObj.inputArtifacts.urlTestConfigFileInfo == null)
+                testObj.inputArtifacts.urlTestConfigFileInfo = testObj.inputArtifacts.urlTestsConfigFileInfo;
+            var inputScriptFileInfo = testObj.kind == mappers_1.TestKind.URL ? testObj.inputArtifacts.urlTestConfigFileInfo : testObj.inputArtifacts.testScriptFileInfo;
             if (validate) {
                 return inputScriptFileInfo.validationStatus;
             }
@@ -184,7 +189,7 @@ function uploadTestPlan() {
         let filepath = map.getTestFile();
         let filename = map.getFileName(filepath);
         var urlSuffix = "tests/" + testId + "/files/" + filename + "?api-version=" + util.apiConstants.tm2023Version;
-        if (map.getTestType() == mappers_1.TestType.URL) {
+        if (map.getTestKind() == mappers_1.TestKind.URL) {
             urlSuffix = urlSuffix + ("&fileType=" + FileType.URL_TEST_CONFIG);
         }
         urlSuffix = baseURL + urlSuffix;

--- a/lib/mappers.js
+++ b/lib/mappers.js
@@ -32,7 +32,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.getTenantId = exports.getFileName = exports.getTestId = exports.getZipFiles = exports.getConfigFiles = exports.getPropertyFile = exports.getTestFile = exports.getYamlPath = exports.getTestType = exports.getDefaultTestRunName = exports.getDefaultTestName = exports.getSubName = exports.getInputParams = exports.getResourceId = exports.getTestHeader = exports.getTestRunHeader = exports.startTestData = exports.dataPlaneHeader = exports.UploadAndValidateHeader = exports.uploadFileData = exports.createTestHeader = exports.createTestData = exports.TestType = void 0;
+exports.getTenantId = exports.getFileName = exports.getTestId = exports.getZipFiles = exports.getConfigFiles = exports.getPropertyFile = exports.getTestFile = exports.getYamlPath = exports.getTestKind = exports.getDefaultTestRunName = exports.getDefaultTestName = exports.getSubName = exports.getInputParams = exports.getResourceId = exports.getTestHeader = exports.getTestRunHeader = exports.startTestData = exports.dataPlaneHeader = exports.UploadAndValidateHeader = exports.uploadFileData = exports.createTestHeader = exports.createTestData = exports.TestKind = void 0;
 const core = __importStar(require("@actions/core"));
 const yaml = require("js-yaml");
 const jwt_decode = require("jwt-decode");
@@ -64,12 +64,12 @@ var kvRefType = null;
 var subnetId = null;
 var splitCSVs = null;
 var certificate = null;
-let testType;
-var TestType;
-(function (TestType) {
-    TestType["URL"] = "URL";
-    TestType["JMX"] = "JMX"; // default
-})(TestType = exports.TestType || (exports.TestType = {}));
+let kind;
+var TestKind;
+(function (TestKind) {
+    TestKind["URL"] = "URL";
+    TestKind["JMX"] = "JMX"; // default
+})(TestKind || (exports.TestKind = TestKind = {}));
 var paramType;
 (function (paramType) {
     paramType["env"] = "env";
@@ -103,14 +103,15 @@ function createTestData() {
         testId: testId,
         description: testdesc,
         displayName: displayName,
-        quickStartTest: false,
+        quickStartTest: false, // always quick test will be false because GH-actions doesnot support it now.
         loadTestConfiguration: {
             engineInstances: engineInstances,
             splitAllCSVs: splitCSVs,
             optionalLoadTestConfig: null
         },
         secrets: secretsYaml,
-        testType: testType,
+        testType: kind,
+        kind: kind,
         certificate: certificate,
         environmentVariables: envYaml,
         passFailCriteria: {
@@ -272,12 +273,12 @@ function getInputParams() {
         if ((0, util_1.isNullOrUndefined)(config.testPlan))
             throw new Error("The required field testPlan is missing in " + YamlPath + ".");
         testPlan = pathLib.join(path, config.testPlan);
-        testType = (_a = config.testType) !== null && _a !== void 0 ? _a : TestType.JMX;
-        if (!isValidTestType(testType)) {
+        kind = (_a = config.testType) !== null && _a !== void 0 ? _a : TestKind.JMX;
+        if (!isValidTestKind(kind)) {
             throw new Error("testType field given is invalid, valid testType are URL and JMX only.");
         }
-        if (config.testType == TestType.URL) {
-            testType = TestType.URL;
+        if (config.testType == TestKind.URL) {
+            kind = TestKind.URL;
             if (!util.checkFileType(testPlan, 'json')) {
                 throw new Error("A test plan of JSON file type is required for a URL test. Please upload a JSON file to run the test.");
             }
@@ -289,7 +290,7 @@ function getInputParams() {
             let tempconfigFiles = [];
             tempconfigFiles = config.configurationFiles;
             for (let file of tempconfigFiles) {
-                if (testType == TestType.URL && !util.checkFileType(file, 'csv')) {
+                if (kind == TestKind.URL && !util.checkFileType(file, 'csv')) {
                     throw new Error("Only CSV files are allowed as configuration files for a URL-based test.");
                 }
                 file = pathLib.join(path, file);
@@ -299,7 +300,7 @@ function getInputParams() {
         if (config.zipArtifacts != undefined) {
             let tempZipFiles = [];
             tempZipFiles = config.zipArtifacts;
-            if (testType == TestType.URL && tempZipFiles.length > 0) {
+            if (kind == TestKind.URL && tempZipFiles.length > 0) {
                 throw new Error("Zip artifacts are not supported for the URL-based test.");
             }
             for (let file of tempZipFiles) {
@@ -322,7 +323,7 @@ function getInputParams() {
             if (!util.checkFileType(config.properties.userPropertyFile, 'properties')) {
                 throw new Error("User property file with extension other than '.properties' is not permitted.");
             }
-            if (testType == TestType.URL) {
+            if (kind == TestKind.URL) {
                 throw new Error("User property file is not supported for the URL-based test.");
             }
             var propFile = config.properties.userPropertyFile;
@@ -372,8 +373,8 @@ function getSubName() {
     });
 }
 exports.getSubName = getSubName;
-function isValidTestType(value) {
-    return Object.values(TestType).includes(value);
+function isValidTestKind(value) {
+    return Object.values(TestKind).includes(value);
 }
 function getAccessToken(aud) {
     return __awaiter(this, void 0, void 0, function* () {
@@ -498,10 +499,10 @@ function validateTestRunParams() {
     if (runDescription && invalidDescription(runDescription))
         throw new Error("Invalid test run description. Test run description must be less than 100 characters.");
 }
-function getTestType() {
-    return testType;
+function getTestKind() {
+    return kind;
 }
-exports.getTestType = getTestType;
+exports.getTestKind = getTestKind;
 function getYamlPath() {
     return YamlPath;
 }
@@ -639,10 +640,11 @@ function getAutoStopCriteria(autoStopInput) {
     if (typeof autoStopInput == "string") {
         if (autoStopInput == "disable") {
             let data = {
-                isAutoStopEnabled: false,
                 autoStopEnabled: false,
+                autoStopDisabled: true,
                 errorRate: 0,
                 errorRateTimeWindow: 0,
+                errorRateTimeWindowInSeconds: 60,
             };
             autoStop = data;
         }
@@ -652,10 +654,11 @@ function getAutoStopCriteria(autoStopInput) {
     }
     else {
         let data = {
-            isAutoStopEnabled: true,
             autoStopEnabled: true,
+            autoStopDisabled: false,
             errorRate: autoStopInput.errorPercentage,
             errorRateTimeWindow: autoStopInput.timeWindow,
+            errorRateTimeWindowInSeconds: autoStopInput.timeWindow,
         };
         autoStop = data;
     }

--- a/lib/util.js
+++ b/lib/util.js
@@ -61,7 +61,7 @@ var apiConstants;
     apiConstants.tm2023Version = '2023-04-01-preview';
     apiConstants.tm2022Version = '2022-11-01';
     apiConstants.cp2022Version = '2022-12-01';
-})(apiConstants = exports.apiConstants || (exports.apiConstants = {}));
+})(apiConstants || (exports.apiConstants = apiConstants = {}));
 const correlationHeader = 'x-ms-correlation-request-id';
 function httpClientRetries(urlSuffix, header, method, retries = 1, data, isUploadCall = true) {
     return __awaiter(this, void 0, void 0, function* () {

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,7 +4,7 @@ import * as map from "./mappers"
 import * as util from './util';
 import * as fs from 'fs';
 import { isNullOrUndefined } from 'util';
-import {TestType} from "./mappers";
+import {TestKind} from "./mappers";
 
 const resultFolder = 'loadTest';
 let baseURL = '';
@@ -57,7 +57,12 @@ async function getTestAPI(validate:boolean) {
         if(testObj == null){
             throw new Error(util.ErrorCorrection(testResult));
         }
-        var inputScriptFileInfo = testObj.testType == TestType.URL ? testObj.inputArtifacts.urlTestsConfigFileInfo :testObj.inputArtifacts.testScriptFileInfo;
+        if (testObj.kind == null){
+            testObj.kind = testObj.testType;
+        }
+        if (testObj.inputArtifacts.urlTestConfigFileInfo == null)
+            testObj.inputArtifacts.urlTestConfigFileInfo = testObj.inputArtifacts.urlTestsConfigFileInfo;
+        var inputScriptFileInfo = testObj.kind == TestKind.URL ? testObj.inputArtifacts.urlTestConfigFileInfo :testObj.inputArtifacts.testScriptFileInfo;
         if(validate){
             return inputScriptFileInfo.validationStatus;
         }
@@ -144,7 +149,7 @@ async function uploadTestPlan()
     let filepath = map.getTestFile();
     let filename = map.getFileName(filepath);
     var urlSuffix = "tests/"+testId+"/files/"+filename+"?api-version="+util.apiConstants.tm2023Version;
-    if(map.getTestType() == TestType.URL){
+    if(map.getTestKind() == TestKind.URL){
         urlSuffix = urlSuffix + ("&fileType="+FileType.URL_TEST_CONFIG);
     }
     urlSuffix = baseURL + urlSuffix;

--- a/src/mappers.ts
+++ b/src/mappers.ts
@@ -32,7 +32,6 @@ var kvRefType: string | null = null;
 var subnetId: string | null = null;
 var splitCSVs: boolean | null = null;
 var certificate: certObj | null = null;
-let testType : TestKind;
 let kind : TestKind;
 export interface certObj {
   type: string;
@@ -107,7 +106,7 @@ export function createTestData() {
       optionalLoadTestConfig : null
     },
     secrets: secretsYaml,
-    testType : testType,
+    testType : kind,
     kind : kind,
     certificate: certificate,
     environmentVariables: envYaml,
@@ -268,13 +267,11 @@ export async function getInputParams() {
       "The required field testPlan is missing in " + YamlPath + "."
     );
   testPlan = pathLib.join(path, config.testPlan);
-  testType = config.testType ?? TestKind.JMX;
-  kind = config.testType ?? TestKind.JMX;
-  if(!isValidTestKind(testType)){
-      throw new Error("testType field given is invalid, valid testType are URL and JMX only.");
+  kind = config.kind ?? config.testType ?? TestKind.JMX;
+  if(!isValidTestKind(kind)){
+      throw new Error("kind field given is invalid, valid kind are URL and JMX only.");
   }
   if(config.testType as TestKind == TestKind.URL){
-      testType = TestKind.URL;
       kind = TestKind.URL;
       if(!util.checkFileType(testPlan,'json')) {
           throw new Error("A test plan of JSON file type is required for a URL test. Please upload a JSON file to run the test.")
@@ -499,8 +496,6 @@ function validateTestRunParams() {
     );
 }
 export function getTestKind(){
-  if (kind == null)
-    return testType;
   return kind;
 }
 export function getYamlPath() {

--- a/src/mappers.ts
+++ b/src/mappers.ts
@@ -32,7 +32,8 @@ var kvRefType: string | null = null;
 var subnetId: string | null = null;
 var splitCSVs: boolean | null = null;
 var certificate: certObj | null = null;
-let testType : TestType;
+let testType : TestKind;
+let kind : TestKind;
 export interface certObj {
   type: string;
   value: string;
@@ -53,14 +54,16 @@ export interface autoStopCriteriaObjIn {
 }
 export interface autoStopCriteriaObjOut {
   autoStopEnabled? : boolean;
+  autoStopDisabled? : boolean;
   errorRate ?: number;
   errorRateTimeWindow ?: number;
+  errorRateTimeWindowInSeconds ?: number;
 }
 export interface paramObj {
   type: string;
   value: string;
 }
-export enum TestType {
+export enum TestKind {
   URL = "URL",
   JMX = "JMX" // default
 }
@@ -105,6 +108,7 @@ export function createTestData() {
     },
     secrets: secretsYaml,
     testType : testType,
+    kind : kind,
     certificate: certificate,
     environmentVariables: envYaml,
     passFailCriteria: {
@@ -264,12 +268,14 @@ export async function getInputParams() {
       "The required field testPlan is missing in " + YamlPath + "."
     );
   testPlan = pathLib.join(path, config.testPlan);
-  testType = config.testType ?? TestType.JMX;
-  if(!isValidTestType(testType)){
+  testType = config.testType ?? TestKind.JMX;
+  kind = config.testType ?? TestKind.JMX;
+  if(!isValidTestKind(testType)){
       throw new Error("testType field given is invalid, valid testType are URL and JMX only.");
   }
-  if(config.testType as TestType == TestType.URL){
-      testType = TestType.URL;
+  if(config.testType as TestKind == TestKind.URL){
+      testType = TestKind.URL;
+      kind = TestKind.URL;
       if(!util.checkFileType(testPlan,'json')) {
           throw new Error("A test plan of JSON file type is required for a URL test. Please upload a JSON file to run the test.")
       }
@@ -281,7 +287,7 @@ export async function getInputParams() {
     let tempconfigFiles: string[] = [];
     tempconfigFiles = config.configurationFiles;
     for(let file of tempconfigFiles){
-      if(testType == TestType.URL && !util.checkFileType(file,'csv')){
+      if(kind == TestKind.URL && !util.checkFileType(file,'csv')){
         throw new Error("Only CSV files are allowed as configuration files for a URL-based test.");
       }
       file = pathLib.join(path, file);
@@ -291,7 +297,7 @@ export async function getInputParams() {
   if(config.zipArtifacts != undefined){
     let tempZipFiles: string[]=[];
     tempZipFiles = config.zipArtifacts;
-    if(testType == TestType.URL && tempZipFiles.length > 0){
+    if(kind == TestKind.URL && tempZipFiles.length > 0){
         throw new Error("Zip artifacts are not supported for the URL-based test.");
     }
     for(let file of tempZipFiles){
@@ -314,7 +320,7 @@ export async function getInputParams() {
       if(!util.checkFileType(config.properties.userPropertyFile, 'properties')){
         throw new Error("User property file with extension other than '.properties' is not permitted.");
       }
-      if(testType == TestType.URL){
+      if(kind == TestKind.URL){
           throw new Error("User property file is not supported for the URL-based test.");
       }
       var propFile = config.properties.userPropertyFile;
@@ -365,8 +371,8 @@ export async function getSubName() {
     throw new Error(message);
   }
 }
-function isValidTestType(value: string): value is TestType {
-  return Object.values(TestType).includes(value as TestType);
+function isValidTestKind(value: string): value is TestKind {
+  return Object.values(TestKind).includes(value as TestKind);
 }
 async function getAccessToken(aud: string) {
   try {
@@ -492,8 +498,10 @@ function validateTestRunParams() {
       "Invalid test run description. Test run description must be less than 100 characters."
     );
 }
-export function getTestType(){
-  return testType;
+export function getTestKind(){
+  if (kind == null)
+    return testType;
+  return kind;
 }
 export function getYamlPath() {
   return YamlPath;
@@ -618,10 +626,11 @@ function getAutoStopCriteria(autoStopInput : autoStopCriteriaObjIn | string | nu
   if (typeof autoStopInput == "string") {
     if (autoStopInput == "disable") {
       let data = {
-        isAutoStopEnabled: false,
         autoStopEnabled: false,
+        autoStopDisabled : true,
         errorRate: 0,
         errorRateTimeWindow: 0,
+        errorRateTimeWindowInSeconds: 60,
       };
       autoStop = data;
     } else {
@@ -631,10 +640,11 @@ function getAutoStopCriteria(autoStopInput : autoStopCriteriaObjIn | string | nu
     }
   } else {
     let data = {
-      isAutoStopEnabled: true,
-      autoStopEnabled: true,
+      autoStopEnabled : true,
+      autoStopDisabled : false,
       errorRate: autoStopInput.errorPercentage,
       errorRateTimeWindow: autoStopInput.timeWindow,
+      errorRateTimeWindowInSeconds: autoStopInput.timeWindow,
     };
     autoStop = data;
   }

--- a/src/mappers.ts
+++ b/src/mappers.ts
@@ -267,9 +267,9 @@ export async function getInputParams() {
       "The required field testPlan is missing in " + YamlPath + "."
     );
   testPlan = pathLib.join(path, config.testPlan);
-  kind = config.kind ?? config.testType ?? TestKind.JMX;
+  kind = config.testType ?? TestKind.JMX;
   if(!isValidTestKind(kind)){
-      throw new Error("kind field given is invalid, valid kind are URL and JMX only.");
+      throw new Error("testType field given is invalid, valid testType are URL and JMX only.");
   }
   if(config.testType as TestKind == TestKind.URL){
       kind = TestKind.URL;


### PR DESCRIPTION
**Title**
Renaming models and their properties in Portal on based on suggestion received on TypeSpec PR.


**Changes**
Added support for new properties along with old properties

testType -> kind
autoStopEnabled -> autoStopDisabled
errorRateTimeWindow -> errorRateTimeWindowInSeconds