### PR TITLE
[phase3: CICD] adding over-ride params and outputVar support in the PipleineYaml.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,13 @@ inputs:
   env:
     description: 'Enter env in JSON'
     required: false
+  overrideParameters:
+    description: 'Override parameters in the YAML config file using the JSON format with testId, displayName, description, engineInstances, autoStop supported.'
+    required: false
+  outputVariableName:
+    description: 'Name of the output variable that stores the test run ID for use in subsequent tasks.'
+    required: false
+
 branding:
     icon: 'extension-icon.svg'
     color: 'blue'

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
 import * as util from './models/FileUtils';
-import { resultFolder } from "./models/UtilModels";
+import { OutputVariableInterface, OutPutVariablesConstants, resultFolder } from "./models/UtilModels";
 import * as fs from 'fs';
 import * as core from '@actions/core';
 import { AuthenticationUtils } from "./models/AuthenticationUtils";
@@ -22,7 +22,12 @@ async function run() {
 
         fs.mkdirSync(resultFolder);
         await apiSupport.createTestAPI();
+        
+        let outputVar: OutputVariableInterface = {
+            testRunId: yamlConfig.runTimeParams.testRunId
+        }
 
+        core.setOutput(`${yamlConfig.outputVariableName}.${OutPutVariablesConstants.testRunId}`, outputVar.testRunId);
     }
     catch (err:any) {
         core.setFailed(err.message);

--- a/src/models/AuthenticationUtils.ts
+++ b/src/models/AuthenticationUtils.ts
@@ -4,6 +4,7 @@ import { execFile } from "child_process";
 import { CallTypeForDP, ContentTypeMap, TokenScope } from "./UtilModels";
 import { jwtDecode, JwtPayload } from "jwt-decode";
 import { IHeaders } from "typed-rest-client/Interfaces";
+import * as InputConstants from "./InputConstants";
 
 export class AuthenticationUtils {
     dataPlanetoken : string = '';
@@ -22,13 +23,13 @@ export class AuthenticationUtils {
         // NOTE: This will set the subscription id
         await this.getTokenAPI(TokenScope.ControlPlane);
 
-        const rg: string | undefined = core.getInput('resourceGroup');
-        const ltres: string | undefined = core.getInput('loadTestResource');
+        const rg: string | undefined = core.getInput(InputConstants.resourceGroup);
+        const ltres: string | undefined = core.getInput(InputConstants.loadTestResource);
         if(isNullOrUndefined(rg) || rg == ''){
-            throw new Error(`The input field "resourceGroup" is empty. Provide an existing resource group name.`);
+            throw new Error(`The input field "${InputConstants.resourceGroupLabel}" is empty. Provide an existing resource group name.`);
         }
         if(isNullOrUndefined(ltres) || ltres == ''){
-            throw new Error(`The input field "loadTestResource" is empty. Provide an existing load test resource name.`);
+            throw new Error(`The input field "${InputConstants.loadTestResourceLabel}" is empty. Provide an existing load test resource name.`);
         }
         this.resourceId = "/subscriptions/"+this.subscriptionId+"/resourcegroups/"+rg+"/providers/microsoft.loadtestservice/loadtests/"+ltres;
 

--- a/src/models/InputConstants.ts
+++ b/src/models/InputConstants.ts
@@ -1,0 +1,22 @@
+export const testRunName = 'loadTestRunName';
+export const runDescription = 'loadTestRunDescription';
+export const overRideParameters = 'overrideParameters';
+export const outputVariableName = 'outputVariableName';
+export const envVars = 'env';
+export const secrets = 'secrets';
+export const serviceConnectionName = 'connectedServiceNameARM';
+export const resourceGroup = 'resourceGroup';
+export const loadTestResource = 'loadTestResource';
+export const loadTestConfigFile = 'loadTestConfigFile';
+
+// labels user visible strings
+export const testRunNameLabel = 'Load Test Run Name';
+export const runDescriptionLabel = 'Load Test Run Description';
+export const overRideParametersLabel = 'Override Parameters';
+export const outputVariableNameLabel = 'Output Variable Name';
+export const envVarsLabel = 'env';
+export const secretsLabel = 'Secrets';
+export const serviceConnectionNameLabel = 'Azure subscription';
+export const resourceGroupLabel = 'Resource Group';
+export const loadTestResourceLabel = 'Load Test Resource';
+export const loadTestConfigFileLabel = 'Load Test Config File';

--- a/src/models/UtilModels.ts
+++ b/src/models/UtilModels.ts
@@ -107,3 +107,11 @@ export interface ValidationModel {
     valid: boolean;
     error: string;
 }
+
+export interface OutputVariableInterface {
+    testRunId: string;
+}
+
+export module OutPutVariablesConstants {
+    export const testRunId = 'testRunId';
+}

--- a/src/models/constants.ts
+++ b/src/models/constants.ts
@@ -1,96 +1,51 @@
-export const defaultYaml: any =
+export class DefaultYamlModel
 {
-    version: 'v0.1',
+    version: string ='';
+    testId: string = '';
+    testName: string = '';
+    displayName: string = '';
+    description: string = '';
+    testPlan: string = '';
+    testType: string = '';
+    engineInstances: number = 0;
+    subnetId: string = '';
+    publicIPDisabled: boolean = false;
+    configurationFiles: Array<string> = [];
+    zipArtifacts: Array<string> = [];
+    splitAllCSVs: boolean = false;
+    properties: { userPropertyFile: string } = { userPropertyFile: '' };
+    env: Array<{ name: string, value: string }> = [];
+    certificates: Array<{ name: string, value: string }> = [];
+    secrets: Array<{ name: string, value: string }> = [];
+    failureCriteria: Array<string> = [];
+    appComponents: Array<{resourceId: string, kind: string, metrics: Array<{name: string, aggregation: string, namespace?: string}>}> = [];
+    autoStop: { errorPercentage: number, timeWindow: number } = { errorPercentage: 0, timeWindow: 0 };
+    keyVaultReferenceIdentity: string = '';
+    keyVaultReferenceIdentityType: string = '';
+    regionalLoadTestConfig: Array<{region: string, engineInstances: number}> = [];
+    referenceIdentities: Array<{kind: string, type: string, value: string}> = [];
+}
+
+export const overRideParamsJSON: any = {
+
     testId: 'SampleTest',
-    testName: 'SampleTest',
-    displayName: 'Sample Test',
+    displayName: 'SampleTest',
     description: 'Load test website home page',
-    testPlan: 'SampleTest.jmx',
-    testType: 'JMX',
-    engineInstances: 2,
-    subnetId: '/subscriptions/abcdef01-2345-6789-0abc-def012345678/resourceGroups/sample-rg/providers/Microsoft.Network/virtualNetworks/load-testing-vnet/subnets/load-testing',
-    publicIPDisabled: false,
-    configurationFiles: ['sampledata.csv'],
-    zipArtifacts: ['bigdata.zip'],
-    splitAllCSVs: true,
-    properties: { userPropertyFile: 'user.properties' },
-    env: [{ name: 'domain', value: 'https://www.contoso-ads.com' }],
-    certificates: [
-        {
-            name: 'my-certificate',
-            value: 'https://akv-contoso.vault.azure.net/certificates/MyCertificate/abc1234567890def12345'
-        }
-    ],
-    secrets: [
-        {
-            name: 'my-secret',
-            value: 'https://akv-contoso.vault.azure.net/secrets/MySecret/abc1234567890def12345'
-        }
-    ],
-    failureCriteria: [
-        'avg(response_time_ms) > 300',
-        'percentage(error) > 50',
-        { GetCustomerDetails: 'avg(latency) >200' }
-    ],
-    appComponents: [
-        {
-            resourceId: "/subscriptions/abcdef01-2345-6789-0abc-def012345678/resourceGroups/sample-rg/providers/Microsoft.Web/serverfarms/sampleApp",
-            kind: "app",
-            metrics:[
-                {
-                    name: "CpuPercentage",
-                    aggregation: "Average"
-                },
-                {
-                    name: "MemoryPercentage",
-                    aggregation: "Average",
-                    namespace: "Microsoft.Web/serverfarms"
-                }
-            ],
-        },
-        {
-            resourceId: "/subscriptions/abcdef01-2345-6789-0abc-def012345678/resourceGroups/sample-rg/providers/Microsoft.KeyVault/vaults/sampleApp",
-            metrics:[
-                {
-                    name: "ServiceApiHit",
-                    aggregation: "Count",
-                    namespace: "Microsoft.KeyVault/vaults"
-                },
-                {
-                    name: "ServiceApiLatency",
-                    aggregation: "Average"
-                }
-            ]
-        }
-    ],
+    engineInstances: 1,
     autoStop: { errorPercentage: 80, timeWindow: 60 },
-    keyVaultReferenceIdentity: '/subscriptions/abcdef01-2345-6789-0abc-def012345678/resourceGroups/sample-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/sample-identity',
-    keyVaultReferenceIdentityType: 'SystemAssigned',
-    regionalLoadTestConfig: [
-        {
-            region: 'eastus',
-            engineInstances: 1,
-        },
-        {
-            region: 'westus',
-            engineInstances: 1,
-        }
-    ],
-    referenceIdentities: [
-        {
-          kind: "KeyVault",
-          type: "UserAssigned",
-          value: "/subscriptions/abcdef01-2345-6789-0abc-def012345678/resourceGroups/sample-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/sample-identity"
-        },
-        {
-          kind: "Metrics",
-          type: "UserAssigned",
-          value: "/subscriptions/abcdef01-2345-6789-0abc-def012345678/resourceGroups/sample-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/sample-identity"
-        }
-    ]
+}
+
+export class OverRideParametersModel {
+    testId: string = '';
+    displayName: string = '';
+    description: string = '';
+    engineInstances: number = 0;
+    autoStop: { errorPercentage: number, timeWindow: number } = { errorPercentage: 0, timeWindow: 0 };
 }
 
 export const testmanagerApiVersion = "2024-07-01-preview";
+
+export const autoStopDisable = "disable";
 
 namespace BaseAPIRoute {
     export const featureFlag = "featureFlags";
@@ -100,3 +55,5 @@ export namespace APIRoute {
     const latestVersion = "api-version="+testmanagerApiVersion;
     export const FeatureFlags = (flag: string) => `${BaseAPIRoute.featureFlag}/${flag}?${latestVersion}`;
 }
+
+export const OutputVariableName = 'ALTOutputVar';

--- a/test/Utils/checkForValidationOfYaml.test.ts
+++ b/test/Utils/checkForValidationOfYaml.test.ts
@@ -206,7 +206,7 @@ describe('reference identity validations', () => {
   });
 
   test('KeyVault inside and outside', () => {
-    expect(checkValidityYaml(referenceIdentityConstants.referenceIdentitiesGivenInKeyVaultOutsideAndInside)).toStrictEqual({valid : false, error : 'KeyVault reference identity should not be provided in the referenceIdentities array if keyVaultReferenceIdentity is provided.'});
+    expect(checkValidityYaml(referenceIdentityConstants.referenceIdentitiesGivenInKeyVaultOutsideAndInside)).toStrictEqual({valid : false, error : 'Two KeyVault references are defined in the YAML config file. Use either the keyVaultReferenceIdentity field or the referenceIdentities section to specify the KeyVault reference identity.'});
   });
 
   test('reference identities is not an array', () => {


### PR DESCRIPTION
[phase3: CICD] adding over-ride params and outputVar support in the PipleineYaml.

Adding support for the outputVar and overRide params from the pipeline to allow users to use templatisation in the pipelines.

testRunId will be available in the outputVar here.

