### PR TITLE
Update Node.js version to 24 and refresh compiled files

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -37,6 +37,6 @@ branding:
     icon: 'extension-icon.svg'
     color: 'blue'
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'lib/main.js'
   post: 'lib/postProcessJob.js'

--- a/lib/RunnerFiles/CreateAndRunTest.js
+++ b/lib/RunnerFiles/CreateAndRunTest.js
@@ -15,23 +15,13 @@ var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (
 }) : function(o, v) {
     o["default"] = v;
 });
-var __importStar = (this && this.__importStar) || (function () {
-    var ownKeys = function(o) {
-        ownKeys = Object.getOwnPropertyNames || function (o) {
-            var ar = [];
-            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
-            return ar;
-        };
-        return ownKeys(o);
-    };
-    return function (mod) {
-        if (mod && mod.__esModule) return mod;
-        var result = {};
-        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
-        __setModuleDefault(result, mod);
-        return result;
-    };
-})();
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {

--- a/lib/Utils/AzCliUtility.js
+++ b/lib/Utils/AzCliUtility.js
@@ -9,8 +9,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.getDPTokens = getDPTokens;
-exports.getAccounts = getAccounts;
+exports.getAccounts = exports.getDPTokens = void 0;
 const child_process_1 = require("child_process");
 function getDPTokens(tokenScope) {
     return __awaiter(this, void 0, void 0, function* () {
@@ -19,12 +18,14 @@ function getDPTokens(tokenScope) {
         return execAz(cmdArguments);
     });
 }
+exports.getDPTokens = getDPTokens;
 function getAccounts(accountType) {
     return __awaiter(this, void 0, void 0, function* () {
         const cmdArguments = accountType === 'Subscription' ? ["account", "show"] : ["cloud", "show"];
         return execAz(cmdArguments);
     });
 }
+exports.getAccounts = getAccounts;
 function execAz(cmdArguments) {
     return __awaiter(this, void 0, void 0, function* () {
         const azCmd = process.platform === "win32" ? "az.cmd" : "az";

--- a/lib/Utils/CommonUtils.js
+++ b/lib/Utils/CommonUtils.js
@@ -15,23 +15,13 @@ var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (
 }) : function(o, v) {
     o["default"] = v;
 });
-var __importStar = (this && this.__importStar) || (function () {
-    var ownKeys = function(o) {
-        ownKeys = Object.getOwnPropertyNames || function (o) {
-            var ar = [];
-            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
-            return ar;
-        };
-        return ownKeys(o);
-    };
-    return function (mod) {
-        if (mod && mod.__esModule) return mod;
-        var result = {};
-        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
-        __setModuleDefault(result, mod);
-        return result;
-    };
-})();
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -42,47 +32,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.isNullOrUndefined = isNullOrUndefined;
-exports.isNull = isNull;
-exports.checkFileType = checkFileType;
-exports.checkFileTypes = checkFileTypes;
-exports.printTestDuration = printTestDuration;
-exports.printCriteria = printCriteria;
-exports.errorCorrection = errorCorrection;
-exports.printClientMetrics = printClientMetrics;
-exports.sleep = sleep;
-exports.getUniqueId = getUniqueId;
-exports.getResultFolder = getResultFolder;
-exports.getReportFolder = getReportFolder;
-exports.indexOfFirstDigit = indexOfFirstDigit;
-exports.TryExtractLeadingInteger = TryExtractLeadingInteger;
-exports.TryExtractLeadingDecimal = TryExtractLeadingDecimal;
-exports.isTerminalTestStatus = isTerminalTestStatus;
-exports.isTerminalFileStatus = isTerminalFileStatus;
-exports.isTerminalFileStatusSucceeded = isTerminalFileStatusSucceeded;
-exports.isStatusFailed = isStatusFailed;
-exports.getResultObj = getResultObj;
-exports.getFileName = getFileName;
-exports.invalidDisplayName = invalidDisplayName;
-exports.invalidDescription = invalidDescription;
-exports.getResourceTypeFromResourceId = getResourceTypeFromResourceId;
-exports.getResourceNameFromResourceId = getResourceNameFromResourceId;
-exports.getResourceGroupFromResourceId = getResourceGroupFromResourceId;
-exports.getSubscriptionIdFromResourceId = getSubscriptionIdFromResourceId;
-exports.validateAutoStop = validateAutoStop;
-exports.validateAndGetSegregatedManagedIdentities = validateAndGetSegregatedManagedIdentities;
-exports.validateOverRideParameters = validateOverRideParameters;
-exports.validateOutputParametervariableName = validateOutputParametervariableName;
-exports.validateUrl = validateUrl;
-exports.validateUrlcert = validateUrlcert;
-exports.invalidName = invalidName;
-exports.inValidEngineInstances = inValidEngineInstances;
-exports.getDefaultTestName = getDefaultTestName;
-exports.getDefaultTestRunName = getDefaultTestRunName;
-exports.getDefaultRunDescription = getDefaultRunDescription;
-exports.validateTestRunParamsFromPipeline = validateTestRunParamsFromPipeline;
-exports.getAllFileErrors = getAllFileErrors;
-exports.sanitisePipelineNameHeader = sanitisePipelineNameHeader;
+exports.sanitisePipelineNameHeader = exports.getAllFileErrors = exports.validateTestRunParamsFromPipeline = exports.getDefaultRunDescription = exports.getDefaultTestRunName = exports.getDefaultTestName = exports.inValidEngineInstances = exports.invalidName = exports.validateUrlcert = exports.validateUrl = exports.validateOutputParametervariableName = exports.validateOverRideParameters = exports.validateAndGetSegregatedManagedIdentities = exports.validateAutoStop = exports.getSubscriptionIdFromResourceId = exports.getResourceGroupFromResourceId = exports.getResourceNameFromResourceId = exports.getResourceTypeFromResourceId = exports.invalidDescription = exports.invalidDisplayName = exports.getFileName = exports.getResultObj = exports.isStatusFailed = exports.isTerminalFileStatusSucceeded = exports.isTerminalFileStatus = exports.isTerminalTestStatus = exports.TryExtractLeadingDecimal = exports.TryExtractLeadingInteger = exports.indexOfFirstDigit = exports.getReportFolder = exports.getResultFolder = exports.getUniqueId = exports.sleep = exports.printClientMetrics = exports.errorCorrection = exports.printCriteria = exports.printTestDuration = exports.checkFileTypes = exports.checkFileType = exports.isNull = exports.isNullOrUndefined = void 0;
 const { v4: uuidv4 } = require('uuid');
 const GeneralConstants_1 = require("../Constants/GeneralConstants");
 const PayloadModels_1 = require("../models/PayloadModels");
@@ -92,9 +42,11 @@ const path = __importStar(require("path"));
 function isNullOrUndefined(value) {
     return value === null || value === undefined;
 }
+exports.isNullOrUndefined = isNullOrUndefined;
 function isNull(value) {
     return value === null;
 }
+exports.isNull = isNull;
 function checkFileType(filePath, fileExtToValidate) {
     if (isNullOrUndefined(filePath)) {
         return false;
@@ -102,6 +54,7 @@ function checkFileType(filePath, fileExtToValidate) {
     let split = filePath.split('.');
     return split[split.length - 1].toLowerCase() == fileExtToValidate.toLowerCase();
 }
+exports.checkFileType = checkFileType;
 function checkFileTypes(filePath, fileExtsToValidate) {
     var _a;
     if (isNullOrUndefined(filePath)) {
@@ -111,6 +64,7 @@ function checkFileTypes(filePath, fileExtsToValidate) {
     let fileExtsToValidateLower = fileExtsToValidate.map(ext => ext.toLowerCase());
     return fileExtsToValidateLower.includes((_a = split[split.length - 1]) === null || _a === void 0 ? void 0 : _a.toLowerCase());
 }
+exports.checkFileTypes = checkFileTypes;
 function printTestDuration(testRunObj) {
     return __awaiter(this, void 0, void 0, function* () {
         var _a, _b;
@@ -123,6 +77,7 @@ function printTestDuration(testRunObj) {
         return;
     });
 }
+exports.printTestDuration = printTestDuration;
 function printCriteria(criteria) {
     if (Object.keys(criteria).length == 0)
         return;
@@ -151,9 +106,11 @@ function printCriteria(criteria) {
     }
     console.log("\n");
 }
+exports.printCriteria = printCriteria;
 function errorCorrection(result) {
     return "Unable to fetch the response. Please re-run or contact support if the issue persists. " + "Status code :" + result.message.statusCode;
 }
+exports.errorCorrection = errorCorrection;
 function printTestResult(criteria) {
     var _a, _b;
     let pass = 0;
@@ -192,6 +149,7 @@ function printClientMetrics(obj) {
         }
     });
 }
+exports.printClientMetrics = printClientMetrics;
 function getAbsVal(data) {
     if (isNullOrUndefined(data)) {
         return "undefined";
@@ -205,33 +163,39 @@ function sleep(ms) {
         setTimeout(resolve, ms);
     });
 }
+exports.sleep = sleep;
 function getUniqueId() {
     return uuidv4();
 }
+exports.getUniqueId = getUniqueId;
 function getResultFolder(testArtifacts) {
     if (isNullOrUndefined(testArtifacts) || isNullOrUndefined(testArtifacts.outputArtifacts))
         return null;
     var outputurl = testArtifacts.outputArtifacts;
     return !isNullOrUndefined(outputurl.resultFileInfo) ? outputurl.resultFileInfo.url : null;
 }
+exports.getResultFolder = getResultFolder;
 function getReportFolder(testArtifacts) {
     if (isNullOrUndefined(testArtifacts) || isNullOrUndefined(testArtifacts.outputArtifacts))
         return null;
     var outputurl = testArtifacts.outputArtifacts;
     return !isNullOrUndefined(outputurl.reportFileInfo) ? outputurl.reportFileInfo.url : null;
 }
+exports.getReportFolder = getReportFolder;
 function indexOfFirstDigit(input) {
     let i = 0;
     for (; input[i] < '0' || input[i] > '9'; i++)
         ;
     return i == input.length ? -1 : i;
 }
+exports.indexOfFirstDigit = indexOfFirstDigit;
 function TryExtractLeadingInteger(input) {
     let i = 0;
     for (; input[i] >= '0' && input[i] <= '9'; i++)
         ;
     return i == input.length ? input : input.substring(0, i);
 }
+exports.TryExtractLeadingInteger = TryExtractLeadingInteger;
 function TryExtractLeadingDecimal(input) {
     let i = 0;
     let decimalSeen = false;
@@ -247,12 +211,14 @@ function TryExtractLeadingDecimal(input) {
     }
     return i == input.length ? input : input.substring(0, i);
 }
+exports.TryExtractLeadingDecimal = TryExtractLeadingDecimal;
 function isTerminalTestStatus(testStatus) {
     if (testStatus == "DONE" || testStatus === "FAILED" || testStatus === "CANCELLED") {
         return true;
     }
     return false;
 }
+exports.isTerminalTestStatus = isTerminalTestStatus;
 function isTerminalFileStatus(fileStatus) {
     let fileStatusEnum = fileStatus;
     if (fileStatusEnum == PayloadModels_1.FileStatus.VALIDATION_INITIATED) {
@@ -260,6 +226,7 @@ function isTerminalFileStatus(fileStatus) {
     }
     return true;
 }
+exports.isTerminalFileStatus = isTerminalFileStatus;
 function isTerminalFileStatusSucceeded(fileStatus) {
     let fileStatusEnum = fileStatus;
     if (isNullOrUndefined(fileStatusEnum) || fileStatusEnum == PayloadModels_1.FileStatus.VALIDATION_SUCCESS || fileStatusEnum == PayloadModels_1.FileStatus.NOT_VALIDATED) {
@@ -267,12 +234,14 @@ function isTerminalFileStatusSucceeded(fileStatus) {
     }
     return false;
 }
+exports.isTerminalFileStatusSucceeded = isTerminalFileStatusSucceeded;
 function isStatusFailed(testStatus) {
     if (testStatus === "FAILED" || testStatus === "CANCELLED") {
         return true;
     }
     return false;
 }
+exports.isStatusFailed = isStatusFailed;
 function getResultObj(data) {
     return __awaiter(this, void 0, void 0, function* () {
         let dataString;
@@ -287,32 +256,40 @@ function getResultObj(data) {
         }
     });
 }
+exports.getResultObj = getResultObj;
 function getFileName(filepath) {
     const filename = path.basename(filepath);
     return filename;
 }
+exports.getFileName = getFileName;
 function invalidDisplayName(value) {
     if (value.length < 2 || value.length > 50)
         return true;
     return false;
 }
+exports.invalidDisplayName = invalidDisplayName;
 function invalidDescription(value) {
     if (value.length > 100)
         return true;
     return false;
 }
+exports.invalidDescription = invalidDescription;
 function getResourceTypeFromResourceId(resourceId) {
     return resourceId && resourceId.split("/").length > 7 ? resourceId.split("/")[6] + "/" + resourceId.split("/")[7] : null;
 }
+exports.getResourceTypeFromResourceId = getResourceTypeFromResourceId;
 function getResourceNameFromResourceId(resourceId) {
     return resourceId && resourceId.split("/").length > 8 ? resourceId.split("/")[8] : null;
 }
+exports.getResourceNameFromResourceId = getResourceNameFromResourceId;
 function getResourceGroupFromResourceId(resourceId) {
     return resourceId && resourceId.split("/").length > 4 ? resourceId.split("/")[4] : null;
 }
+exports.getResourceGroupFromResourceId = getResourceGroupFromResourceId;
 function getSubscriptionIdFromResourceId(resourceId) {
     return resourceId && resourceId.split("/").length > 2 ? resourceId.split("/")[2] : null;
 }
+exports.getSubscriptionIdFromResourceId = getSubscriptionIdFromResourceId;
 function validateAutoStop(autoStop, isPipelineParam = false) {
     if (typeof autoStop != 'string') {
         if (isNullOrUndefined(autoStop.errorPercentage) || isNaN(autoStop.errorPercentage) || autoStop.errorPercentage > 100 || autoStop.errorPercentage < 0) {
@@ -336,6 +313,7 @@ function validateAutoStop(autoStop, isPipelineParam = false) {
     }
     return { valid: true, error: "" };
 }
+exports.validateAutoStop = validateAutoStop;
 function validateAndGetSegregatedManagedIdentities(referenceIdentities, keyVaultGivenOutOfReferenceIdentities = false) {
     let referenceIdentityValuesUAMIMap = {
         [UtilModels_1.ReferenceIdentityKinds.KeyVault]: [],
@@ -382,6 +360,7 @@ function validateAndGetSegregatedManagedIdentities(referenceIdentities, keyVault
     }
     return { referenceIdentityValuesUAMIMap, referenceIdentiesSystemAssignedCount };
 }
+exports.validateAndGetSegregatedManagedIdentities = validateAndGetSegregatedManagedIdentities;
 function validateOverRideParameters(overRideParams) {
     try {
         if (!isNullOrUndefined(overRideParams)) {
@@ -437,54 +416,64 @@ function validateOverRideParameters(overRideParams) {
     }
     return { valid: true, error: "" };
 }
+exports.validateOverRideParameters = validateOverRideParameters;
 function validateOutputParametervariableName(outputVarName) {
     if (isNullOrUndefined(outputVarName) || typeof outputVarName != 'string' || !/^[A-Za-z_][A-Za-z0-9_]*$/.test(outputVarName)) {
         return { valid: false, error: `Invalid output variable name '${outputVarName}'. Use only letters, numbers, and underscores.` };
     }
     return { valid: true, error: "" };
 }
+exports.validateOutputParametervariableName = validateOutputParametervariableName;
 function validateUrl(url) {
     var r = new RegExp(/(http|https):\/\/.*\/secrets\/.+$/);
     return r.test(url);
 }
+exports.validateUrl = validateUrl;
 function validateUrlcert(url) {
     var r = new RegExp(/(http|https):\/\/.*\/certificates\/.+$/);
     return r.test(url);
 }
+exports.validateUrlcert = validateUrlcert;
 function invalidName(value) {
     if (value.length < 2 || value.length > 50)
         return true;
     var r = new RegExp(/[^a-z0-9_-]+/);
     return r.test(value);
 }
+exports.invalidName = invalidName;
 function inValidEngineInstances(engines) {
     if (engines > 400 || engines < 1) {
         return true;
     }
     return false;
 }
+exports.inValidEngineInstances = inValidEngineInstances;
 function getDefaultTestName() {
     const a = (new Date(Date.now())).toLocaleString();
     const b = a.split(", ");
     const c = a.split(" ");
     return "Test_" + b[0] + "_" + c[1] + c[2];
 }
+exports.getDefaultTestName = getDefaultTestName;
 function getDefaultTestRunName() {
     const a = (new Date(Date.now())).toLocaleString();
     const b = a.split(", ");
     const c = a.split(" ");
     return "TestRun_" + b[0] + "_" + c[1] + c[2];
 }
+exports.getDefaultTestRunName = getDefaultTestRunName;
 function getDefaultRunDescription() {
     const pipelineName = process.env.GITHUB_WORKFLOW || "Unknown Pipeline";
     return "Started using GH workflows" + (pipelineName ? "-" + pipelineName : "");
 }
+exports.getDefaultRunDescription = getDefaultRunDescription;
 function validateTestRunParamsFromPipeline(runTimeParams) {
     if (runTimeParams.runDisplayName && invalidDisplayName(runTimeParams.runDisplayName))
         throw new Error("Invalid test run name. Test run name must be between 2 to 50 characters.");
     if (runTimeParams.runDescription && invalidDescription(runTimeParams.runDescription))
         throw new Error("Invalid test run description. Test run description must be less than 100 characters.");
 }
+exports.validateTestRunParamsFromPipeline = validateTestRunParamsFromPipeline;
 function getAllFileErrors(testObj) {
     var _a, _b, _c, _d, _e, _f;
     let allArtifacts = [];
@@ -508,6 +497,7 @@ function getAllFileErrors(testObj) {
     }
     return fileErrors;
 }
+exports.getAllFileErrors = getAllFileErrors;
 /**
  * This function returns the string with only ascii charaters, removing the non-ascii characters.
  * @param pipelineName - original pipeline name
@@ -531,3 +521,4 @@ function sanitisePipelineNameHeader(pipelineName) {
     }
     return result;
 }
+exports.sanitisePipelineNameHeader = sanitisePipelineNameHeader;

--- a/lib/Utils/CoreUtils.js
+++ b/lib/Utils/CoreUtils.js
@@ -15,37 +15,24 @@ var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (
 }) : function(o, v) {
     o["default"] = v;
 });
-var __importStar = (this && this.__importStar) || (function () {
-    var ownKeys = function(o) {
-        ownKeys = Object.getOwnPropertyNames || function (o) {
-            var ar = [];
-            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
-            return ar;
-        };
-        return ownKeys(o);
-    };
-    return function (mod) {
-        if (mod && mod.__esModule) return mod;
-        var result = {};
-        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
-        __setModuleDefault(result, mod);
-        return result;
-    };
-})();
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.exportVariable = exportVariable;
-exports.debug = debug;
-exports.getInput = getInput;
-exports.getBoolInput = getBoolInput;
-exports.setFailed = setFailed;
-exports.setOutput = setOutput;
+exports.setOutput = exports.setFailed = exports.getBoolInput = exports.getInput = exports.debug = exports.exportVariable = void 0;
 const core = __importStar(require("@actions/core"));
 function exportVariable(name, value) {
     core.exportVariable(name, value);
 }
+exports.exportVariable = exportVariable;
 function debug(message) {
     core.debug(message);
 }
+exports.debug = debug;
 function getInput(name) {
     let variable = core.getInput(name, { trimWhitespace: true });
     if (variable == '') {
@@ -53,6 +40,7 @@ function getInput(name) {
     }
     return variable;
 }
+exports.getInput = getInput;
 function getBoolInput(name, defaultValue = false) {
     try {
         return core.getBooleanInput(name, { required: true });
@@ -61,9 +49,12 @@ function getBoolInput(name, defaultValue = false) {
         return defaultValue;
     }
 }
+exports.getBoolInput = getBoolInput;
 function setFailed(message) {
     core.setFailed(message);
 }
+exports.setFailed = setFailed;
 function setOutput(name, value) {
     core.setOutput(name, value);
 }
+exports.setOutput = setOutput;

--- a/lib/Utils/CreateAndRunUtils.js
+++ b/lib/Utils/CreateAndRunUtils.js
@@ -15,34 +15,15 @@ var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (
 }) : function(o, v) {
     o["default"] = v;
 });
-var __importStar = (this && this.__importStar) || (function () {
-    var ownKeys = function(o) {
-        ownKeys = Object.getOwnPropertyNames || function (o) {
-            var ar = [];
-            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
-            return ar;
-        };
-        return ownKeys(o);
-    };
-    return function (mod) {
-        if (mod && mod.__esModule) return mod;
-        var result = {};
-        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
-        __setModuleDefault(result, mod);
-        return result;
-    };
-})();
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.addExistingTestParameters = addExistingTestParameters;
-exports.addExistingAppComponentParameters = addExistingAppComponentParameters;
-exports.getPayloadForTest = getPayloadForTest;
-exports.getPayloadForAppcomponents = getPayloadForAppcomponents;
-exports.getPayloadForServerMetricsConfig = getPayloadForServerMetricsConfig;
-exports.getAllFileNamesTobeDeleted = getAllFileNamesTobeDeleted;
-exports.validateAndGetRunTimeParamsForTestRun = validateAndGetRunTimeParamsForTestRun;
-exports.getTestRunPayload = getTestRunPayload;
-exports.validateAndGetOutPutVarName = validateAndGetOutPutVarName;
-exports.validateAndSetOverrideParams = validateAndSetOverrideParams;
+exports.validateAndSetOverrideParams = exports.validateAndGetOutPutVarName = exports.getTestRunPayload = exports.validateAndGetRunTimeParamsForTestRun = exports.getAllFileNamesTobeDeleted = exports.getPayloadForServerMetricsConfig = exports.getPayloadForAppcomponents = exports.getPayloadForTest = exports.addExistingAppComponentParameters = exports.addExistingTestParameters = void 0;
 const CommonUtils_1 = require("./CommonUtils");
 const UtilModels_1 = require("../models/UtilModels");
 const Util = __importStar(require("./CommonUtils"));
@@ -64,6 +45,7 @@ function addExistingTestParameters(testObj, existingParams) {
         existingParams.env = testObj.environmentVariables;
     }
 }
+exports.addExistingTestParameters = addExistingTestParameters;
 function addExistingAppComponentParameters(appcomponents, existingParams) {
     var _a, _b, _c;
     if (appcomponents) {
@@ -80,6 +62,7 @@ function addExistingAppComponentParameters(appcomponents, existingParams) {
         }
     }
 }
+exports.addExistingAppComponentParameters = addExistingAppComponentParameters;
 function getPayloadForTest(loadTestConfig, existingParams) {
     let passFailCriteria = mergePassFailCriteria(loadTestConfig, existingParams);
     let passFailServerCriteria = mergePassFailServerCriteria(loadTestConfig, existingParams);
@@ -114,6 +97,7 @@ function getPayloadForTest(loadTestConfig, existingParams) {
     };
     return createdata;
 }
+exports.getPayloadForTest = getPayloadForTest;
 function getPayloadForAppcomponents(loadTestConfig, existingData) {
     let appComponentsMerged = loadTestConfig.appComponents;
     for (let [resourceId, keys] of existingData.appComponents) {
@@ -135,6 +119,7 @@ function getPayloadForAppcomponents(loadTestConfig, existingData) {
     };
     return appcomponents;
 }
+exports.getPayloadForAppcomponents = getPayloadForAppcomponents;
 function getPayloadForServerMetricsConfig(existingServerCriteria, loadTestConfig) {
     var _a, _b, _c;
     let mergedServerCriteria = loadTestConfig.serverMetricsConfig;
@@ -151,6 +136,7 @@ function getPayloadForServerMetricsConfig(existingServerCriteria, loadTestConfig
     };
     return serverMetricsConfig;
 }
+exports.getPayloadForServerMetricsConfig = getPayloadForServerMetricsConfig;
 function getAllFileNamesTobeDeleted(loadTestConfig, testFiles) {
     let filesToDelete = [];
     if (testFiles.userPropFileInfo != null) {
@@ -179,6 +165,7 @@ function getAllFileNamesTobeDeleted(loadTestConfig, testFiles) {
     }
     return filesToDelete;
 }
+exports.getAllFileNamesTobeDeleted = getAllFileNamesTobeDeleted;
 function validateAndGetRunTimeParamsForTestRun(testId) {
     var _a, _b;
     var secretRun = CoreUtils.getInput(InputConstants.secrets);
@@ -227,6 +214,7 @@ function validateAndGetRunTimeParamsForTestRun(testId) {
     runTimeParams.testId = testId;
     return runTimeParams;
 }
+exports.validateAndGetRunTimeParamsForTestRun = validateAndGetRunTimeParamsForTestRun;
 function getTestRunPayload(runTimeParams) {
     let testRunPayload = {
         environmentVariables: runTimeParams.env,
@@ -238,6 +226,7 @@ function getTestRunPayload(runTimeParams) {
     };
     return testRunPayload;
 }
+exports.getTestRunPayload = getTestRunPayload;
 function validateAndGetOutPutVarName() {
     var _a;
     let outputVarName = (_a = CoreUtils.getInput(InputConstants.outputVariableName)) !== null && _a !== void 0 ? _a : GeneralConstants_1.OutputVariableName; // for now keeping the validations here, later shift to the tasklib class when written.
@@ -248,6 +237,7 @@ function validateAndGetOutPutVarName() {
     }
     return outputVarName;
 }
+exports.validateAndGetOutPutVarName = validateAndGetOutPutVarName;
 function validateAndSetOverrideParams(loadTestConfig) {
     let overRideParams = CoreUtils.getInput(InputConstants.overRideParameters);
     let validation = Util.validateOverRideParameters(overRideParams);
@@ -274,6 +264,7 @@ function validateAndSetOverrideParams(loadTestConfig) {
         }
     }
 }
+exports.validateAndSetOverrideParams = validateAndSetOverrideParams;
 function mergePassFailCriteria(loadTestConfig, existingData) {
     let existingCriteria = existingData.passFailCriteria;
     let existingCriteriaIds = Object.keys(existingCriteria);

--- a/lib/Utils/EngineUtil.js
+++ b/lib/Utils/EngineUtil.js
@@ -1,12 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.Resources = exports.LoadTestFramework = void 0;
-exports.getOrderedLoadTestFrameworks = getOrderedLoadTestFrameworks;
-exports.getLoadTestFrameworkModel = getLoadTestFrameworkModel;
-exports.getLoadTestFrameworkDisplayName = getLoadTestFrameworkDisplayName;
-exports.isTestKindConvertibleToJMX = isTestKindConvertibleToJMX;
-exports.getLoadTestFrameworkFromKind = getLoadTestFrameworkFromKind;
-exports.getLoadTestFrameworkModelFromKind = getLoadTestFrameworkModelFromKind;
+exports.Resources = exports.getLoadTestFrameworkModelFromKind = exports.getLoadTestFrameworkFromKind = exports.isTestKindConvertibleToJMX = exports.getLoadTestFrameworkDisplayName = exports.getLoadTestFrameworkModel = exports.getOrderedLoadTestFrameworks = exports.LoadTestFramework = void 0;
 const JMeterFrameworkModel_1 = require("../models/engine/JMeterFrameworkModel");
 const LocustFrameworkModel_1 = require("../models/engine/LocustFrameworkModel");
 const TestKind_1 = require("../models/TestKind");
@@ -27,6 +21,7 @@ var LoadTestFramework;
 function getOrderedLoadTestFrameworks() {
     return [LoadTestFramework.JMeter, LoadTestFramework.Locust];
 }
+exports.getOrderedLoadTestFrameworks = getOrderedLoadTestFrameworks;
 /**
  * Returns the corresponding LoadTestFrameworkModel based on the provided LoadTestFramework enum.
  * If the provided framework is not recognized, it assumes JMeter by default.
@@ -44,6 +39,7 @@ function getLoadTestFrameworkModel(framework) {
             return _jmeterFramework;
     }
 }
+exports.getLoadTestFrameworkModel = getLoadTestFrameworkModel;
 /**
  * Retrieves the display name of a load test framework.
  * @param framework The load test framework.
@@ -52,6 +48,7 @@ function getLoadTestFrameworkModel(framework) {
 function getLoadTestFrameworkDisplayName(framework) {
     return getLoadTestFrameworkModel(framework).frameworkDisplayName;
 }
+exports.getLoadTestFrameworkDisplayName = getLoadTestFrameworkDisplayName;
 /**
  * Checks if a given test kind is convertible to JMX.
  * If the kind is not provided, it assumes JMX by default.
@@ -65,6 +62,7 @@ function isTestKindConvertibleToJMX(kind) {
     }
     return kind === TestKind_1.TestKind.URL;
 }
+exports.isTestKindConvertibleToJMX = isTestKindConvertibleToJMX;
 /**
  * Retrieves the load test framework from a given test kind.
  * If no kind is provided, it assumes JMX by default.
@@ -85,6 +83,7 @@ function getLoadTestFrameworkFromKind(kind) {
             return LoadTestFramework.JMeter;
     }
 }
+exports.getLoadTestFrameworkFromKind = getLoadTestFrameworkFromKind;
 /**
  * Retrieves the load test framework model from a given test kind.
  * If no kind is provided, it assumes JMX by default.
@@ -94,6 +93,7 @@ function getLoadTestFrameworkFromKind(kind) {
 function getLoadTestFrameworkModelFromKind(kind) {
     return getLoadTestFrameworkModel(getLoadTestFrameworkFromKind(kind));
 }
+exports.getLoadTestFrameworkModelFromKind = getLoadTestFrameworkModelFromKind;
 var Resources;
 (function (Resources) {
     let Strings;

--- a/lib/Utils/FetchUtils.js
+++ b/lib/Utils/FetchUtils.js
@@ -15,23 +15,13 @@ var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (
 }) : function(o, v) {
     o["default"] = v;
 });
-var __importStar = (this && this.__importStar) || (function () {
-    var ownKeys = function(o) {
-        ownKeys = Object.getOwnPropertyNames || function (o) {
-            var ar = [];
-            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
-            return ar;
-        };
-        return ownKeys(o);
-    };
-    return function (mod) {
-        if (mod && mod.__esModule) return mod;
-        var result = {};
-        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
-        __setModuleDefault(result, mod);
-        return result;
-    };
-})();
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -42,7 +32,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.httpClientRetries = httpClientRetries;
+exports.httpClientRetries = void 0;
 const CommonUtils_1 = require("./CommonUtils");
 const UtilModels_1 = require("./../models/UtilModels");
 const httpc = __importStar(require("typed-rest-client/HttpClient"));
@@ -116,3 +106,4 @@ function httpClientRetries(urlSuffix_1, header_1, method_1) {
         }
     });
 }
+exports.httpClientRetries = httpClientRetries;

--- a/lib/Utils/FileUtils.js
+++ b/lib/Utils/FileUtils.js
@@ -15,23 +15,13 @@ var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (
 }) : function(o, v) {
     o["default"] = v;
 });
-var __importStar = (this && this.__importStar) || (function () {
-    var ownKeys = function(o) {
-        ownKeys = Object.getOwnPropertyNames || function (o) {
-            var ar = [];
-            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
-            return ar;
-        };
-        return ownKeys(o);
-    };
-    return function (mod) {
-        if (mod && mod.__esModule) return mod;
-        var result = {};
-        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
-        __setModuleDefault(result, mod);
-        return result;
-    };
-})();
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -45,9 +35,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.uploadFileToResultsFolder = uploadFileToResultsFolder;
-exports.deleteFile = deleteFile;
-exports.uploadFileData = uploadFileData;
+exports.uploadFileData = exports.deleteFile = exports.uploadFileToResultsFolder = void 0;
 const path_1 = __importDefault(require("path"));
 const UtilModels_1 = require("./../models/UtilModels");
 const fs = __importStar(require("fs"));
@@ -76,6 +64,7 @@ function uploadFileToResultsFolder(response_1) {
         }
     });
 }
+exports.uploadFileToResultsFolder = uploadFileToResultsFolder;
 function deleteFile(foldername) {
     if (fs.existsSync(foldername)) {
         fs.readdirSync(foldername).forEach((file, index) => {
@@ -90,6 +79,7 @@ function deleteFile(foldername) {
         fs.rmdirSync(foldername);
     }
 }
+exports.deleteFile = deleteFile;
 function uploadFileData(filepath) {
     try {
         let filedata = fs.readFileSync(filepath);
@@ -104,3 +94,4 @@ function uploadFileData(filepath) {
         throw new Error(err.message);
     }
 }
+exports.uploadFileData = uploadFileData;

--- a/lib/Utils/LoadtestConfigUtil.js
+++ b/lib/Utils/LoadtestConfigUtil.js
@@ -15,23 +15,13 @@ var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (
 }) : function(o, v) {
     o["default"] = v;
 });
-var __importStar = (this && this.__importStar) || (function () {
-    var ownKeys = function(o) {
-        ownKeys = Object.getOwnPropertyNames || function (o) {
-            var ar = [];
-            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
-            return ar;
-        };
-        return ownKeys(o);
-    };
-    return function (mod) {
-        if (mod && mod.__esModule) return mod;
-        var result = {};
-        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
-        __setModuleDefault(result, mod);
-        return result;
-    };
-})();
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.LoadtestConfigUtil = void 0;
 const CommonUtils_1 = require("./CommonUtils");

--- a/lib/Utils/PassFailCriteriaUtil.js
+++ b/lib/Utils/PassFailCriteriaUtil.js
@@ -1,7 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.getPassFailCriteriaFromString = getPassFailCriteriaFromString;
-exports.getServerCriteriaFromYaml = getServerCriteriaFromYaml;
+exports.getServerCriteriaFromYaml = exports.getPassFailCriteriaFromString = void 0;
 const UtilModels_1 = require("../models/UtilModels");
 const CommonUtils_1 = require("./CommonUtils");
 /*
@@ -54,6 +53,7 @@ function getPassFailCriteriaFromString(passFailCriteria) {
     });
     return failureCriteriaValue;
 }
+exports.getPassFailCriteriaFromString = getPassFailCriteriaFromString;
 function getServerCriteriaFromYaml(serverMetricsCriteria) {
     let serverPFCriteriaValue = [];
     serverMetricsCriteria.forEach((criteria) => {
@@ -69,6 +69,7 @@ function getServerCriteriaFromYaml(serverMetricsCriteria) {
     });
     return serverPFCriteriaValue;
 }
+exports.getServerCriteriaFromYaml = getServerCriteriaFromYaml;
 /*
     ado takes the full pf criteria as a string after parsing the string into proper data model,
     this is to avoid duplicates of the data by keeping the full aggrregated metric

--- a/lib/Utils/TaskParametersUtil.js
+++ b/lib/Utils/TaskParametersUtil.js
@@ -15,23 +15,13 @@ var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (
 }) : function(o, v) {
     o["default"] = v;
 });
-var __importStar = (this && this.__importStar) || (function () {
-    var ownKeys = function(o) {
-        ownKeys = Object.getOwnPropertyNames || function (o) {
-            var ar = [];
-            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
-            return ar;
-        };
-        return ownKeys(o);
-    };
-    return function (mod) {
-        if (mod && mod.__esModule) return mod;
-        var result = {};
-        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
-        __setModuleDefault(result, mod);
-        return result;
-    };
-})();
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {

--- a/lib/Utils/YamlValidationUtil.js
+++ b/lib/Utils/YamlValidationUtil.js
@@ -15,25 +15,15 @@ var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (
 }) : function(o, v) {
     o["default"] = v;
 });
-var __importStar = (this && this.__importStar) || (function () {
-    var ownKeys = function(o) {
-        ownKeys = Object.getOwnPropertyNames || function (o) {
-            var ar = [];
-            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
-            return ar;
-        };
-        return ownKeys(o);
-    };
-    return function (mod) {
-        if (mod && mod.__esModule) return mod;
-        var result = {};
-        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
-        __setModuleDefault(result, mod);
-        return result;
-    };
-})();
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.validateYamlConfig = validateYamlConfig;
+exports.validateYamlConfig = void 0;
 const CommonUtils_1 = require("./CommonUtils");
 const UtilModels_1 = require("../models/UtilModels");
 const CommonUtils_2 = require("./CommonUtils");
@@ -191,6 +181,7 @@ function validateYamlConfig(givenYaml) {
     }
     return { valid: true, error: "" };
 }
+exports.validateYamlConfig = validateYamlConfig;
 function validateFailureCriteria(failureCriteria) {
     var _a, _b, _c, _d, _e, _f, _g, _h;
     if (!Array.isArray(failureCriteria)) {

--- a/lib/main.js
+++ b/lib/main.js
@@ -15,23 +15,13 @@ var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (
 }) : function(o, v) {
     o["default"] = v;
 });
-var __importStar = (this && this.__importStar) || (function () {
-    var ownKeys = function(o) {
-        ownKeys = Object.getOwnPropertyNames || function (o) {
-            var ar = [];
-            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
-            return ar;
-        };
-        return ownKeys(o);
-    };
-    return function (mod) {
-        if (mod && mod.__esModule) return mod;
-        var result = {};
-        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
-        __setModuleDefault(result, mod);
-        return result;
-    };
-})();
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {

--- a/lib/postProcessJob.js
+++ b/lib/postProcessJob.js
@@ -15,23 +15,13 @@ var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (
 }) : function(o, v) {
     o["default"] = v;
 });
-var __importStar = (this && this.__importStar) || (function () {
-    var ownKeys = function(o) {
-        ownKeys = Object.getOwnPropertyNames || function (o) {
-            var ar = [];
-            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
-            return ar;
-        };
-        return ownKeys(o);
-    };
-    return function (mod) {
-        if (mod && mod.__esModule) return mod;
-        var result = {};
-        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
-        __setModuleDefault(result, mod);
-        return result;
-    };
-})();
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -42,7 +32,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.run = run;
+exports.run = void 0;
 const UtilModels_1 = require("./models/UtilModels");
 const CoreUtils = __importStar(require("./Utils/CoreUtils"));
 const AuthenticatorService_1 = require("./services/AuthenticatorService");
@@ -69,4 +59,5 @@ function run() {
         }
     });
 }
+exports.run = run;
 run();

--- a/lib/services/APIService.js
+++ b/lib/services/APIService.js
@@ -15,23 +15,13 @@ var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (
 }) : function(o, v) {
     o["default"] = v;
 });
-var __importStar = (this && this.__importStar) || (function () {
-    var ownKeys = function(o) {
-        ownKeys = Object.getOwnPropertyNames || function (o) {
-            var ar = [];
-            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
-            return ar;
-        };
-        return ownKeys(o);
-    };
-    return function (mod) {
-        if (mod && mod.__esModule) return mod;
-        var result = {};
-        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
-        __setModuleDefault(result, mod);
-        return result;
-    };
-})();
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {

--- a/lib/services/AuthenticatorService.js
+++ b/lib/services/AuthenticatorService.js
@@ -15,23 +15,13 @@ var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (
 }) : function(o, v) {
     o["default"] = v;
 });
-var __importStar = (this && this.__importStar) || (function () {
-    var ownKeys = function(o) {
-        ownKeys = Object.getOwnPropertyNames || function (o) {
-            var ar = [];
-            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
-            return ar;
-        };
-        return ownKeys(o);
-    };
-    return function (mod) {
-        if (mod && mod.__esModule) return mod;
-        var result = {};
-        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
-        __setModuleDefault(result, mod);
-        return result;
-    };
-})();
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {

--- a/lib/services/FeatureFlagService.js
+++ b/lib/services/FeatureFlagService.js
@@ -15,23 +15,13 @@ var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (
 }) : function(o, v) {
     o["default"] = v;
 });
-var __importStar = (this && this.__importStar) || (function () {
-    var ownKeys = function(o) {
-        ownKeys = Object.getOwnPropertyNames || function (o) {
-            var ar = [];
-            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
-            return ar;
-        };
-        return ownKeys(o);
-    };
-    return function (mod) {
-        if (mod && mod.__esModule) return mod;
-        var result = {};
-        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
-        __setModuleDefault(result, mod);
-        return result;
-    };
-})();
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     },
     "devDependencies": {
         "@types/jest": "^29.5.12",
-        "@types/node": "^20.11.30",
+        "@types/node": "^24",
         "@types/sinon": "^17.0.4",
         "jest": "^29.7.0",
         "jest-junit": "^16.0.0",


### PR DESCRIPTION
The load-testing GitHub action is running with node version 20 which reached end of life at the end of April 2026. To prevent the action from failing to run, a workaround is to set the action environment variable `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION` to `true`. This pull request updates the node version so it is no longer using a deprecated version. 

### Changes:
- updated node version in action and package.json to 24
- ran `npm run compile` and committed the updated compiled files

Resolves #155